### PR TITLE
Rectified the setting name

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,3 +1,3 @@
 # copy this file to .env and fill in the <templates>
-AUTHO_DOMAIN=<domain>.auth0.com
+AUTH0_DOMAIN=<domain>.auth0.com
 AUTH0_CLIENTID=<from https://manage.auth0.com/#/applications Settings>


### PR DESCRIPTION
Replaced the alphabetic 'O' with the numeric 0 (zero), which was causing settings issue when deployed.