### PR TITLE
Reason for failure added.

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,5 +6,11 @@ var lib = require('./lib');
 module.exports.handler = function( event, context ) {
   lib.authenticate( event )
     .then( context.succeed )
-    .catch( context.fail );
+    .catch(function (err) {
+      if (err.message == "Unauthorized") {
+        context.fail("Unauthorized");
+      } else {
+        context.fail(err.message);
+      }
+    });
 };


### PR DESCRIPTION
Lambda requires "Unauthorized" as argument in context.fail function to show 401 error. Otherwise it will always show 500 Internal error.