### PR TITLE
Added Code Highlighting Markup to RegEx in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ In the left panel, under your API name, click on **Custom Authorizers**. Click o
 * Lambda region : < from previous step >
 * Execution role : < the ARN of the Role we created in the previous step > 
 * Identity token source : method.request.header.Authorization
-* Token validation expression : '''^Bearer [-0-9a-zA-z\.]*$'''
+* Token validation expression : ```^Bearer [-0-9a-zA-z\.]*$```
 ** Cut-and-paste this regular expression from ^ to $ inclusive
 * Result TTL in seconds : 3600
 

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ In the left panel, under your API name, click on **Custom Authorizers**. Click o
 * Lambda region : < from previous step >
 * Execution role : < the ARN of the Role we created in the previous step > 
 * Identity token source : method.request.header.Authorization
-* Token validation expression : ^Bearer [-0-9a-zA-z\.]*$
+* Token validation expression : '''^Bearer [-0-9a-zA-z\.]*$'''
 ** Cut-and-paste this regular expression from ^ to $ inclusive
 * Result TTL in seconds : 3600
 


### PR DESCRIPTION
Updated markup in regex with code highlighting (3 backticks). The asterisks in the text and markup were transforming the regex to make it incorrect when viewing in browser.  