### PR TITLE
Spelling and clean-up

### DIFF
--- a/dynamo.json
+++ b/dynamo.json
@@ -1,6 +1,0 @@
-{
-    "TableName" : "Users",
-    "Item"      : {
-        "userId" : ""
-    }
-}

--- a/lib.js
+++ b/lib.js
@@ -4,7 +4,7 @@
 
 var ACCESS_TOKEN_LENGTH = 16; // (aparent) length of an Autho0 access_token
 
-// since AWS Lambda doesn't (yet) provide environment varibles, load them from .env
+// since AWS Lambda doesn't (yet) provide environment variables, load them from .env
 require('dotenv').config();
 
 var fs = require('fs');


### PR DESCRIPTION
Removed ‘dynamo.json’ to keep it consistent with the docs, as
‘dynamo.json.sample’ already exists.

Fixed spelling in a comment in 'lib.js'