### PR TITLE
Minor README and comment fix and updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ The Message is the authorization data that the Lambda function returns to API Ga
 
 ### Create bundle
 
-You can create the bundle using `npm zip`. This creates a lambda-auth0-authorizer.zip deployment package with all the source, configuration and node modules AWS Lambda needs.
+You can create the bundle using `npm run zip`. This creates a lambda-auth0-authorizer.zip deployment package with all the source, configuration and node modules AWS Lambda needs.
 
 ### Create Lambda function
 

--- a/README.md
+++ b/README.md
@@ -199,6 +199,25 @@ That Role will need to have a Policy similar to the following:
         ]
     }
 
+You will also need to set a "Trust Relationship for the role". This will allow the API Gateway permission to assume the role and run the lambda function. The trust relationship can be set in a separate tab in the AWS console. Click the "Edit Trust Relationship button". It should look similar to the following:
+
+    {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Principal": {
+            "Service": [
+              "apigateway.amazonaws.com",
+              "lambda.amazonaws.com"
+            ]
+          },
+          "Action": "sts:AssumeRole"
+        }
+      ]
+    }
+
+
 ### Configure API Gateway
 
 From the AWS console https://console.aws.amazon.com/apigateway/home

--- a/lib.js
+++ b/lib.js
@@ -4,7 +4,9 @@
 
 var ACCESS_TOKEN_LENGTH = 16; // (apparent) length of an Autho0 access_token
 
-// since AWS Lambda doesn't (yet) provide environment variables, load them from .env
+// Lambda now supports environment variables - http://docs.aws.amazon.com/lambda/latest/dg/tutorial-env_cli.html
+// a .env file can be used as a development convenience. Real environment variables can be used in deployment and
+// will override anything loaded by dotenv.
 require('dotenv').config();
 
 var fs = require('fs');


### PR DESCRIPTION
I updated the README:

• Package should be created by running 'npm run zip' and not 'npm zip'.
• I added a section on the need to add a 'trust relationship' to the IAM role that allows API Gateway to invoke the custom authorizer lambda. I got an error without the trust relationship.

I updated the comment in lib.js to reflect the fact that lambda now supports env vars.