### PR TITLE
support getting domain & client id from SSM

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,3 +1,5 @@
 # copy this file to .env and fill in the <templates>
 AUTH0_DOMAIN=<domain>.auth0.com
+AUTH0_DOMAIN_PARAMETER=ssm-parameter-name
 AUTH0_CLIENTID=<from https://manage.auth0.com/#/applications Settings>
+AUTH0_CLIENTID_PARAMETER=ssm-parameter-name

--- a/README.md
+++ b/README.md
@@ -49,7 +49,12 @@ Values specified in this file will set the corresponding environment variables.
 You will need to set:
 
     AUTH0_DOMAIN=mydomain.auth0.com
+    # or:
+    AUTH0_DOMAIN_PARAMETER=ssm-parameter-name
+
     AUTH0_CLIENTID=MyClientId
+    # or:
+    AUTH0_CLIENTID_PARAMETER=ssm-parameter-name
 
 You can obtain these values from your Auth0 [Application settings](https://manage.auth0.com/#/applications).
 

--- a/index.js
+++ b/index.js
@@ -8,7 +8,6 @@ module.exports.handler = function( event, context ) {
     .then( context.succeed )
     .catch( err => {
       if ( ! err ) context.fail( "Unhandled error case" );
-//      if ( err.message ) context.fail( err.message );
       context.fail( err );
     });
 };


### PR DESCRIPTION
Many companies separate their AWS accounts for testing a production purposes. Similar Auth0 separation exist for obvious reasons.

It is common to store per-account configuration (e.g. for Auth0) in SSM Parameter Store, so that for example resources in the production AWS account use the production Auth0 account and resources in the testing AWS account use the test Auth0 account.

I have added the ability to specify parameter names instead of constant environment variables, making the authorizer fetch the SSM parameter from the environment and create the relevant client according to it.